### PR TITLE
support bootup with syncer

### DIFF
--- a/helm/templates/stateful-set.yaml
+++ b/helm/templates/stateful-set.yaml
@@ -29,7 +29,33 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+       {{- if .Values.syncer.enabled }}
+        - name: syncer
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - node
+          - src/syncer.js
+          volumeMounts:
+            - name: sqlite-volume
+              mountPath: /app/sqlite
+            - name: cache-volume
+              mountPath: /app/cache
+          env:
+            - name: BULLMQ_HOST
+              value: localhost
+            - name: GW_TLS_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  key: ca.crt
+                  name: redis-crt
+          envFrom:
+            - secretRef:
+                name: dre
+        {{- end }}
+        - name: listener
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 2
 
+syncer:
+  enabled: true
+
 image:
   repository: warpredstone/dre
   pullPolicy: Always


### PR DESCRIPTION
Dear all,
  Today, while working on the DevOps-related tasks for our client, I noticed that your infrastructure code is not complete. In order for your listener to work properly, it actually requires the syncer to be running at the same time. However, based on your architecture, it seems like you may only need one global syncer. To maintain a less intrusive approach, we have added an additional container that can be toggled by the user. Please review the code.